### PR TITLE
CU-86a5z8qhx-BS Lib - Replace base url to access ETH data provider so…

### DIFF
--- a/common/changes/@cityofzion/bs-ethereum/CU-86a5z8qhx_2024-12-19-21-01.json
+++ b/common/changes/@cityofzion/bs-ethereum/CU-86a5z8qhx_2024-12-19-21-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cityofzion/bs-ethereum",
+      "comment": "Update Moralis URL",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cityofzion/bs-ethereum"
+}

--- a/packages/bs-ethereum/src/__tests__/EthersLedgerServiceEthereum.spec.ts
+++ b/packages/bs-ethereum/src/__tests__/EthersLedgerServiceEthereum.spec.ts
@@ -5,9 +5,9 @@ import Transport from '@ledgerhq/hw-transport'
 import { BSEthereum } from '../BSEthereum'
 import { BSEthereumConstants } from '../constants/BSEthereumConstants'
 
-let ledgerService: EthersLedgerServiceEthereum
+let ledgerService: EthersLedgerServiceEthereum<'ethereum'>
 let transport: Transport
-let bsEthereum: BSEthereum
+let bsEthereum: BSEthereum<'ethereum'>
 
 describe.skip('EthersLedgerServiceEthereum', () => {
   beforeAll(async () => {

--- a/packages/bs-ethereum/src/services/blockchain-data/MoralisBDSEthereum.ts
+++ b/packages/bs-ethereum/src/services/blockchain-data/MoralisBDSEthereum.ts
@@ -94,7 +94,7 @@ interface MoralisTokenMetadataResponse {
 }
 
 export class MoralisBDSEthereum extends RpcBDSEthereum {
-  static BASE_URL = 'https://nxlrja2d1a.execute-api.us-east-1.amazonaws.com/production'
+  static BASE_URL = 'https://dora.coz.io/api/v2/meta'
 
   static SUPPORTED_CHAINS = [
     '1',


### PR DESCRIPTION
… it uses coz dns