### PR TITLE
Update API base URL

### DIFF
--- a/packages/blockchain-service/src/constants/BSCommonConstants.ts
+++ b/packages/blockchain-service/src/constants/BSCommonConstants.ts
@@ -1,3 +1,3 @@
 export class BSCommonConstants {
-  static readonly DORA_URL = 'https://dora.coz.io'
+  static readonly DORA_URL = 'https://api.coz.io'
 }


### PR DESCRIPTION
The old URL will stop working eventually. The new URL has the added benefit that `403` and `404` errors are not longer redirected to `index.html` thus allowing you to see the actual reason for failure in the response message.