### PR TITLE
Update NeoX staging domain

### DIFF
--- a/common/changes/@cityofzion/bs-neox/fix-neox_2026-07-13-12-38.json
+++ b/common/changes/@cityofzion/bs-neox/fix-neox_2026-07-13-12-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cityofzion/bs-neox",
+      "comment": "Update stage API domain",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cityofzion/bs-neox"
+}

--- a/packages/blockchain-service/src/constants/BSCommonConstants.ts
+++ b/packages/blockchain-service/src/constants/BSCommonConstants.ts
@@ -1,4 +1,5 @@
 export class BSCommonConstants {
   static readonly COZ_API_URL = 'https://api.coz.io'
+  static readonly COZ_API_STAGE_URL = 'https://api-stage.coz.io'
   static readonly DORA_URL = 'https://dora.coz.io'
 }

--- a/packages/bs-neox/src/services/blockchain-data/BlockscoutBDSNeoX.ts
+++ b/packages/bs-neox/src/services/blockchain-data/BlockscoutBDSNeoX.ts
@@ -31,7 +31,7 @@ import type {
 export class BlockscoutBDSNeoX extends RpcBDSEthereum<TBSNeoXName, TBSNeoXNetworkId, IBSNeoX> {
   static readonly BASE_URL_BY_CHAIN_ID: Partial<Record<TBSNeoXNetworkId, string>> = {
     '47763': `${BSCommonConstants.COZ_API_URL}/api/neox/mainnet`,
-    '12227332': 'https://dora-stage.coz.io/api/neox/testnet',
+    '12227332': `${BSCommonConstants.COZ_API_STAGE_URL}/api/neox/testnet`,
   }
 
   static getClient(network: TBSNetwork<TBSNeoXNetworkId>) {


### PR DESCRIPTION
It is the last remaining API endpoint that uses the `dora-stage` domain instead of `api-stage`